### PR TITLE
Add rectangular outer shape option

### DIFF
--- a/perf_dxf_generator.py
+++ b/perf_dxf_generator.py
@@ -14,36 +14,74 @@ def get_float(prompt, default=None):
         print("Invalid input. Please enter a number.")
         return get_float(prompt, default)
 
-outer_diameter = get_float("Enter outer diameter in inches (e.g. 25.875): ")
+shape_choice = input("Choose outer shape (circle or rectangle) [circle]: ").strip().lower() or "circle"
+if shape_choice not in {"circle", "rectangle"}:
+    print("Invalid choice. Defaulting to circle.")
+    shape_choice = "circle"
+
+if shape_choice == "rectangle":
+    outer_length = get_float("Enter outer length in inches (e.g. 24): ")
+    outer_width = get_float("Enter outer width in inches (e.g. 18): ")
+else:
+    outer_diameter = get_float("Enter outer diameter in inches (e.g. 25.875): ")
+
 offset = get_float("Enter offset from edge in inches (default 0.125): ", default=0.125)
 square_size = get_float("Enter square size in inches (e.g. 1): ")
 spacing = get_float("Enter spacing between squares in inches (e.g. 0.1875): ")
 
-# --- Derived Parameters ---
-inner_radius = (outer_diameter / 2) - offset
 step = square_size + spacing
 
 # --- DXF Setup ---
 doc = ezdxf.new()
 msp = doc.modelspace()
 
-# Draw outer circle
-msp.add_circle(center=(0, 0), radius=outer_diameter / 2)
+if shape_choice == "rectangle":
+    inner_length = outer_length - 2 * offset
+    inner_width = outer_width - 2 * offset
+    if inner_length <= 0 or inner_width <= 0:
+        raise ValueError("Offset too large for given rectangle dimensions.")
 
-# Create inner clipping circle using shapely
-circle = Point(0, 0).buffer(inner_radius, resolution=180)
+    outer_rect = Polygon([
+        (-outer_length / 2, -outer_width / 2),
+        (outer_length / 2, -outer_width / 2),
+        (outer_length / 2, outer_width / 2),
+        (-outer_length / 2, outer_width / 2),
+    ])
+    msp.add_lwpolyline(list(outer_rect.exterior.coords), close=True)
 
-# Calculate grid extents
-grid_span = inner_radius * 2 + square_size
-grid_steps = math.ceil(grid_span / step)
-grid_width = grid_steps * step
-grid_offset = -grid_width / 2  # Center at (0, 0)
+    clipping_shape = Polygon([
+        (-inner_length / 2, -inner_width / 2),
+        (inner_length / 2, -inner_width / 2),
+        (inner_length / 2, inner_width / 2),
+        (-inner_length / 2, inner_width / 2),
+    ])
+
+    grid_span_x = inner_length + square_size
+    grid_span_y = inner_width + square_size
+else:
+    inner_radius = (outer_diameter / 2) - offset
+    if inner_radius <= 0:
+        raise ValueError("Offset too large for given diameter.")
+
+    msp.add_circle(center=(0, 0), radius=outer_diameter / 2)
+
+    clipping_shape = Point(0, 0).buffer(inner_radius, resolution=180)
+
+    grid_span_x = inner_radius * 2 + square_size
+    grid_span_y = grid_span_x
+
+grid_steps_x = math.ceil(grid_span_x / step)
+grid_steps_y = math.ceil(grid_span_y / step)
+grid_width_x = grid_steps_x * step
+grid_width_y = grid_steps_y * step
+grid_offset_x = -grid_width_x / 2
+grid_offset_y = -grid_width_y / 2
 
 # Loop over grid positions
-x = grid_offset
-while x < -grid_offset + grid_width:
-    y = grid_offset
-    while y < -grid_offset + grid_width:
+x = grid_offset_x
+while x < -grid_offset_x + grid_width_x:
+    y = grid_offset_y
+    while y < -grid_offset_y + grid_width_y:
         square = Polygon([
             (0, 0),
             (square_size, 0),
@@ -51,7 +89,7 @@ while x < -grid_offset + grid_width:
             (0, square_size)
         ])
         square_moved = translate(square, xoff=x, yoff=y)
-        clipped = square_moved.intersection(circle)
+        clipped = square_moved.intersection(clipping_shape)
 
         if not clipped.is_empty:
             if clipped.geom_type == 'Polygon':
@@ -63,7 +101,7 @@ while x < -grid_offset + grid_width:
     x += step
 
 # Save DXF
-output_filename = "circle_grid_trimmed_centered.dxf"
+output_filename = f"{shape_choice}_grid_trimmed_centered.dxf"
 doc.saveas(output_filename)
 print(f"Saved as {output_filename}")
 


### PR DESCRIPTION
## Summary
- let user choose between circle or rectangle outer shape
- prompt for length and width when rectangle is selected
- generate DXF based on chosen shape

## Testing
- `python -m py_compile perf_dxf_generator.py`
- `python perf_dxf_generator.py <<'EOF'
circle
25
0.125
1
0.1875
EOF` *(fails: ModuleNotFoundError: No module named 'ezdxf')*

------
https://chatgpt.com/codex/tasks/task_e_6883b697ad28833398f244b4b0638cde