### PR TITLE
Set DXF units to inches

### DIFF
--- a/perf_dxf_generator.py
+++ b/perf_dxf_generator.py
@@ -41,6 +41,7 @@ step = square_size + spacing
 
 # --- DXF Setup ---
 doc = ezdxf.new()
+doc.header["$INSUNITS"] = 1
 msp = doc.modelspace()
 
 if shape_choice == "rectangle":


### PR DESCRIPTION
## Summary
- set the generated DXF files to use inches as the insertion units

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d563b22d7883339545060e0b34e57c